### PR TITLE
feat: フォロー中のユーザーのリレーを取得してタイムラインを強化

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ use tokio::runtime::Runtime;
 // serde と serde_json を使って設定ファイルとNIP-01メタデータを構造体として定義
 use serde::{Serialize, Deserialize};
 
-use self::nostr_client::{connect_to_relays_with_nip65, fetch_nip01_profile};
+use self::nostr_client::{connect_to_relays_with_nip65, fetch_nip01_profile, fetch_relays_for_followed_users};
 
 const CONFIG_FILE: &str = "config.json"; // 設定ファイル名
 const MAX_STATUS_LENGTH: usize = 140; // ステータス最大文字数


### PR DESCRIPTION
フォローしているユーザーのkind:10002 (リレーリスト) をDiscoverリレーから取得し、そのリレーに一時的に接続してkind:30315 (ステータスメッセージ) を取得するようにタイムラインの更新処理を修正しました。

これにより、フォローしているユーザーが自身と異なるリレーを利用している場合でも、そのユーザーのステータスメッセージをタイムラインに表示できるようになります。

主な変更点:
- `nostr_client.rs`:
  - `fetch_relays_for_followed_users`関数を追加し、複数の公開鍵に対するkind:10002イベントの取得を実装。
- `ui.rs`:
  - タイムライン更新時に`fetch_relays_for_followed_users`を呼び出すように処理を修正。
  - 取得したリレーに一時的に接続し、ステータス取得後に切断するロジックを追加。
- `main.rs`:
  - `fetch_relays_for_followed_users`をモジュール外に公開。