### PR TITLE
Fix: PNG画像の表示に対応し、デバッグ出力を削除

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ eframe = { version = "0.32.0", features = ["persistence"] } # "testing" を削�
 epaint = "0.32.0"
 egui = "0.32.0"
 env_logger = "0.10"
-egui_extras = { version = "0.32.0", features = ["image", "svg", "http"] }
-image = { version = "0.25", features = ["webp", "gif", "jpeg", "png", "ico"] }
+egui_extras = { version = "0.32.0", features = ["all_loaders", "http"] }
 resvg = "0.45"
 usvg = "0.45"

--- a/src/nostr_client.rs
+++ b/src/nostr_client.rs
@@ -142,10 +142,8 @@ pub async fn fetch_relays_for_followed_users(
     }
 
     let filter = Filter::new().authors(pubkeys).kind(Kind::RelayList);
-    println!("Fetching kind:10002 for {} pubkeys from discover relays.", filter.authors.as_ref().map_or(0, |a| a.len()));
 
     let events = discover_client.get_events_of(vec![filter], Some(Duration::from_secs(10))).await?;
-    println!("Received {} kind:10002 events.", events.len());
 
     let mut relay_urls = std::collections::HashSet::new();
     for event in events {
@@ -153,12 +151,9 @@ pub async fn fetch_relays_for_followed_users(
             if let Tag::RelayMetadata(url, policy) = tag {
                 match policy {
                     Some(nostr::RelayMetadata::Write) | None => {
-                        println!("DEBUG: Adding write-capable relay for user {}: {}", event.pubkey.to_string(), url.to_string());
                         relay_urls.insert(url.to_string());
                     }
-                    Some(nostr::RelayMetadata::Read) => {
-                        println!("DEBUG: Ignoring read-only relay for user {}: {}", event.pubkey.to_string(), url.to_string());
-                    }
+                    Some(nostr::RelayMetadata::Read) => {}
                 }
             }
         }
@@ -184,7 +179,6 @@ pub async fn fetch_nip01_profile(client: &Client, public_key: PublicKey) -> Resu
             while let Ok(notification) = notifications.recv().await {
                 if let nostr_sdk::RelayPoolNotification::Event { event, .. } = notification {
                     if event.kind == Kind::Metadata && event.pubkey == public_key {
-                        println!("NIP-01 profile event received.");
                         profile_json_string = event.content.clone();
                         received_nip01 = true;
                         break;

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -333,14 +333,13 @@ impl eframe::App for NostrStatusApp {
                                     let cloned_app_data_arc = app_data_arc_clone.clone();
                                     runtime_handle.spawn(async move {
                                         if passphrase != confirm_passphrase {
-                                            eprintln!("Error: Passphrases do not match!");
                                             let mut current_app_data = cloned_app_data_arc.lock().unwrap();
                                             current_app_data.is_loading = false;
                                             current_app_data.should_repaint = true; // 再描画をリクエスト
                                             return;
                                         }
 
-                                        let result: Result<Keys, Box<dyn std::error::Error + Send + Sync>> = (|| {
+                                        let _result: Result<Keys, Box<dyn std::error::Error + Send + Sync>> = (|| {
                                             let user_provided_keys = Keys::parse(&secret_key_input)?;
                                             if user_provided_keys.secret_key().is_err() { return Err("入力された秘密鍵は無効です。".into()); }
                                             let mut salt_bytes = [0u8; 16];
@@ -520,23 +519,6 @@ impl eframe::App for NostrStatusApp {
                                         });
                                     });
                             }
-                            // --- テスト画像表示 ---
-                            card_frame.show(ui, |ui| {
-                                ui.label("--- Image Loader Test ---");
-                                ui.add_space(10.0);
-
-                                // JPEG形式のテスト画像URL (Picsum Photos)
-                                let test_uri_jpeg = "https://picsum.photos/id/237/100/100";
-                                ui.label("JPEG Test Image:");
-                                ui.add(egui::Image::from_uri(test_uri_jpeg).fit_to_exact_size(egui::vec2(100.0, 100.0)));
-                                ui.add_space(5.0);
-
-                                // PNG形式のテスト画像URL (Placeholder.com)
-                                let test_uri_png = "https://via.placeholder.com/100x100.png?text=PNG+Test";
-                                ui.label("PNG Test Image:");
-                                ui.add(egui::Image::from_uri(test_uri_png).fit_to_exact_size(egui::vec2(100.0, 100.0)));
-                            });
-                            ui.add_space(15.0);
                             // --- タイムライン表示 ---
                             card_frame.show(ui, |ui| {
                                 ui.heading("Timeline");
@@ -651,17 +633,12 @@ impl eframe::App for NostrStatusApp {
                                                         // --- Profile Picture ---
                                                         let avatar_size = egui::vec2(32.0, 32.0);
                                                         if !post.author_metadata.picture.is_empty() {
-                                                            println!("DEBUG: Displaying picture for pubkey {}: {}",
-                                                                     post.author_pubkey.to_bech32().unwrap_or_default(),
-                                                                     post.author_metadata.picture);
                                                             ui.add(
                                                                 egui::Image::from_uri(&post.author_metadata.picture)
                                                                     .corner_radius(avatar_size.x / 2.0)
                                                                     .fit_to_exact_size(avatar_size)
                                                             );
                                                         } else {
-                                                            println!("DEBUG: No picture URL for pubkey {}. Displaying fallback.",
-                                                                     post.author_pubkey.to_bech32().unwrap_or_default());
                                                             // フォールバックとして四角いスペースを表示
                                                             let (rect, _) = ui.allocate_exact_size(avatar_size, egui::Sense::hover());
                                                             ui.painter().rect_filled(rect, avatar_size.x / 2.0, ui.style().visuals.widgets.inactive.bg_fill);
@@ -878,7 +855,6 @@ impl eframe::App for NostrStatusApp {
                                         ui.label(public_key_bech32.clone());
                                         if ui.button("📋 Copy").clicked() {
                                             ctx.copy_text(public_key_bech32);
-                                            println!("Public key copied to clipboard!");
                                             app_data.should_repaint = true; // 再描画をリクエスト
                                         }
                                     });


### PR DESCRIPTION
`egui_extras` の `all_loaders` feature を有効にすることで、PNG画像が表示されない問題を修正しました。

また、不要になったテストコードと `image` クレートの直接の依存関係、およびデバッグ用の `println!` を削除し、`unused variable` の警告を解消しました。