### PR TITLE
feat: Display music and podcast statuses in timeline

### DIFF
--- a/src/nostr_client.rs
+++ b/src/nostr_client.rs
@@ -395,6 +395,7 @@ pub async fn fetch_timeline_events(
                     content: event.content.clone(),
                     created_at: event.created_at,
                     emojis,
+                    tags: event.tags.to_vec(),
                 });
             }
             timeline_posts.sort_by_key(|p| std::cmp::Reverse(p.created_at));

--- a/src/types.rs
+++ b/src/types.rs
@@ -84,6 +84,8 @@ pub struct TimelinePost {
     pub created_at: Timestamp,
     #[serde(default)]
     pub emojis: HashMap<String, String>,
+    #[serde(default)]
+    pub tags: Vec<nostr::Tag>,
 }
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]

--- a/src/ui/home_view.rs
+++ b/src/ui/home_view.rs
@@ -17,9 +17,41 @@ fn render_post_content(
     post: &TimelinePost,
     urls_to_load: &mut Vec<(String, ImageKind)>,
 ) {
+    let text_color = app_data.current_theme.text_color();
+
+    // Check for music/podcast status
+    let d_tag = post
+        .tags
+        .iter()
+        .find(|t| (*t).clone().to_vec().get(0).map(|s| s.as_str()) == Some("d"));
+
+    if let Some(tag) = d_tag {
+        let tag_vec = tag.clone().to_vec();
+        if tag_vec.get(1).map(|s| s.as_str()) == Some("music") {
+            // Music or Podcast status
+            ui.horizontal(|ui| {
+                ui.label("🎵"); // Use a general music icon for now
+                ui.vertical(|ui| {
+                    ui.label(egui::RichText::new(&post.content).color(text_color));
+                    let r_tag = post
+                        .tags
+                        .iter()
+                        .find(|t| (*t).clone().to_vec().get(0).map(|s| s.as_str()) == Some("r"));
+                    if let Some(r_tag_value) = r_tag.and_then(|t| t.clone().to_vec().get(1).cloned()) {
+                        ui.hyperlink_to(
+                            egui::RichText::new(&r_tag_value).small().color(egui::Color32::GRAY),
+                            r_tag_value,
+                        );
+                    }
+                });
+            });
+            return; // Don't render general content
+        }
+    }
+
+    // General status (with emojis)
     let re = Regex::new(r":(\w+):").unwrap();
     let mut last_end = 0;
-    let text_color = app_data.current_theme.text_color();
 
     ui.horizontal_wrapped(|ui| {
         for cap in re.captures_iter(&post.content) {


### PR DESCRIPTION
This commit introduces the ability to display music and podcast statuses from followed users in the main timeline.

The application is a status message client and will now correctly render these specific status updates.

The changes include:
- Modifying the `TimelinePost` struct to store Nostr event tags.
- Implementing new rendering logic in the home view to detect and display music/podcast statuses with a special format, including a music icon and a hyperlink to the associated resource.